### PR TITLE
Pcf 62

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Runs Sentieon STAR-Aligner to align RNA sequence data to a reference
 eggd_staraligner takes an input array of fastq.gz files and runs sentieon STAR aligner on the fastqs to align them to the reference genome. 
 
 ## What does this app output?
-eggd_staraligner outputs a .bam and .bam.bai file for the alignment of the sample and a Chimeric.out.junctions file with junction information. It also outputs several Sentieon STAR aligner log files and a .bam file with the duplicate reads marked
+eggd_staraligner outputs a .bam and .bam.bai file for the alignment of the sample and a Chimeric.out.junctions file with junction information. It also outputs several Sentieon STAR aligner log files, a .bam file with the duplicate reads marked, and a corresponding .bam.bai index file.
 
 ## This app was made by East GLH

--- a/dxapp.json
+++ b/dxapp.json
@@ -89,6 +89,15 @@
         "help": ""
       },
       {
+        "name": "output_mark_duplicates_bam_bai",
+        "label": "A bai index file, for the output bam file with duplicate reads marked by STAR",
+        "class": "file",
+        "patterns": [
+          "*.mark_duplicates.star.bam.bai"
+        ],
+        "help": ""
+      },
+      {
       "name": "logs",
       "label": "Sentieon STAR aligner log files",
       "class": "array:file",

--- a/src/script.sh
+++ b/src/script.sh
@@ -12,6 +12,7 @@ mkdir -p /home/dnanexus/out/output_bam
 mkdir /home/dnanexus/out/output_bam_bai
 mkdir /home/dnanexus/out/chimeric_junctions
 mkdir /home/dnanexus/out/output_mark_duplicates_bam
+mkdir /home/dnanexus/out/output_mark_duplicates_bam_bai
 mkdir /home/dnanexus/out/logs
 
 # Unpack tarred files 
@@ -188,14 +189,19 @@ sentieon STAR --runThreadN ${NUMBER_THREADS} \
     ${parameters} \
     | sentieon util sort -r ${REFERENCE} -o ${SORTED_BAM} -t ${NUMBER_THREADS} -i -
 
-# Take the output bam file and run the STAR command to mark the duplicates. This generates a .mark_duplicates.star.Processed.out.bam file with the duplicates marked
+# Take the output bam file and run the STAR command to mark the duplicates. 
+# This generates a .mark_duplicates.star.Processed.out.bam file with the duplicates marked
+# Generate a .bai index file for the duplicate-marked bam
 sentieon STAR --runMode inputAlignmentsFromBAM --inputBAMfile ${SORTED_BAM} --bamRemoveDuplicatesType UniqueIdentical --outFileNamePrefix /home/dnanexus/out/${sample_name}.mark_duplicates.star.
+sentieon util index /home/dnanexus/out/${sample_name}.mark_duplicates.star.Processed.out.bam
+
 
 # Move output files to /out directory so they will be uploaded
 mv /home/dnanexus/out/${sample_name}.star.bam /home/dnanexus/out/output_bam
 mv /home/dnanexus/out/${sample_name}.star.bam.bai /home/dnanexus/out/output_bam_bai
 mv /home/dnanexus/Chimeric.out.junction /home/dnanexus/out/chimeric_junctions/${sample_name}.chimeric.out.junction
 mv /home/dnanexus/out/${sample_name}.mark_duplicates.star.Processed.out.bam /home/dnanexus/out/output_mark_duplicates_bam
+mv /home/dnanexus/out/${sample_name}.mark_duplicates.star.Processed.out.bam.bai /home/dnanexus/out/output_mark_duplicates_bam_bai
 mv /home/dnanexus/Log* /home/dnanexus/out/logs
 
 dx-upload-all-outputs


### PR DESCRIPTION
# Changes
Minor changes were made so that the duplicate-marked BAM has a 'bai' index created for it. Previously, an index file was only produced for the un-marked BAM file.

# Testing
Testing just focused on ensuring that the .bam.bai file was produced correctly.
The new branch was build into: "applet-GP76vb042QQj3qp7KvXV80YG" in project 003_220805_STAR-Aligner.
Arguments were copied from a known-functioning StarAligner run on the SeraSeq control sample.
See test job: job-GP773YQ42QQVxJZ77Jgbfg7X

## Inputs

dx run applet-GP76vb042QQj3qp7KvXV80YG \
-ifastqs=file-GBBG8Vj425gx12GQPKpQzzQG \
-ifastqs=file-GBBG8X8425gggYxfPX650z6Q \
-ifastqs=file-GBBG970425gzPyqPPXk9YJYk \
-ifastqs=file-GBBG97Q425gQpky77F0GPbFk \
-isentieon_tar=file-GFbv1x841V8V2zFP8vKf37QZ \
-ictat_genome_indices_read_length=151 \
-igenome_lib=file-GJfX12j41p4GY5K3PY65VFjj


## Outputs

Outputs are in: /test_PCF_62
A .bai is produced for the .bam
.bai: file-GP77yxj4XyyBg36746vkPFf3
.bam: file-GP77yk04XyyPvxxp5JYgG2vF


## Basic sanity check

All the expected output files are produced, including the .BAM.BAI file.

## Is the resulting .BAM.BAI valid?

The BAM and its new BAI were downloaded to a local laptop:
dx download file-GP77yk04XyyPvxxp5JYgG2vF
dx download file-GP77yxj4XyyBg36746vkPFf3

The IGV browser app (https://igv.org/app/) was used to select and open both files as tracks.
The BAM reads appeared successfully and displayed information for CIC, a gene known to be captured in this assay, indicating that the index file is valid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_staraligner/2)
<!-- Reviewable:end -->
