### PR TITLE
Specify R1 and R2 strings better

### DIFF
--- a/src/script.sh
+++ b/src/script.sh
@@ -39,8 +39,8 @@ SENTIEON_BIN_DIR=$(echo $SENTIEON_INSTALL_DIR/bin)
 export PATH="$SENTIEON_BIN_DIR:$PATH"
 
 cd /home/dnanexus/fastqs  # Move into fastqs directory to list fastqs
-R1=($(ls *R1*))
-R2=($(ls *R2*))
+R1=($(ls *_R1_*))
+R2=($(ls *_R2_*))
 
 ### Tests
 ## Check that there are the same number of files in each list

--- a/src/script.sh
+++ b/src/script.sh
@@ -79,8 +79,8 @@ _trim_fastq_endings () {
   echo ${fastq_array[@]}
 }
 
-R1_test=$(_trim_fastq_endings "R1" ${R1[@]})
-R2_test=$(_trim_fastq_endings "R2" ${R2[@]})
+R1_test=$(_trim_fastq_endings "_R1_" ${R1[@]})
+R2_test=$(_trim_fastq_endings "_R2_" ${R2[@]})
 
 # Test that when "R1" and "R2" are removed the two arrays have identical file names
 for i in "${!R1_test[@]}"; do


### PR DESCRIPTION
R1 and R2 searches are too flexible and can filter out the R1 or R2 from elsewhere (e.g 23PCR1) which causes issues. The search has been filtered to "\_R1_" and "\_R2_" as there is always the underscore delimiter.

Passed job with new code: https://platform.dnanexus.com/projects/GYxKj504k171KX9QPxp19q49/monitor/job/GZ067284k17Fx92bB932jzgP

Failed job with old code: https://platform.dnanexus.com/projects/GYxKj504k171KX9QPxp19q49/monitor/job/GZ05Xy04k172BzjqYYK5J0BQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_staraligner/5)
<!-- Reviewable:end -->
