### PR TITLE
Make chimeric junction file output optional

### DIFF
--- a/src/script.sh
+++ b/src/script.sh
@@ -206,10 +206,13 @@ sentieon util index /home/dnanexus/out/${sample_name}.mark_duplicates.star.Proce
 # Move output files to /out directory so they will be uploaded
 mv /home/dnanexus/out/${sample_name}.star.bam /home/dnanexus/out/output_bam
 mv /home/dnanexus/out/${sample_name}.star.bam.bai /home/dnanexus/out/output_bam_bai
-mv /home/dnanexus/Chimeric.out.junction /home/dnanexus/out/chimeric_junctions/${sample_name}.chimeric.out.junction
 mv /home/dnanexus/out/${sample_name}.mark_duplicates.star.Processed.out.bam /home/dnanexus/out/output_mark_duplicates_bam
 mv /home/dnanexus/out/${sample_name}.mark_duplicates.star.Processed.out.bam.bai /home/dnanexus/out/output_mark_duplicates_bam_bai
 for f in Log*; do mv "$f" "${sample_name}.$f"; done
 mv /home/dnanexus/${sample_name}.Log* /home/dnanexus/out/logs
+
+if [ -f *.chimeric.out.junction ]; then
+  mv /home/dnanexus/Chimeric.out.junction /home/dnanexus/out/chimeric_junctions/${sample_name}.chimeric.out.junction
+fi
 
 dx-upload-all-outputs


### PR DESCRIPTION
Using STAR aligner on default mode without `opt_paramter` set doesnt output chimeric junction file which is a required output.
Failed job: https://platform.dnanexus.com/panx/projects/GFfV0qQ42QQVf6VX12zxxvx3/monitor/job/Gkf64FQ42QQf2Vpj5P435Jqk

Passed job: https://platform.dnanexus.com/panx/projects/GFfV0qQ42QQVf6VX12zxxvx3/monitor/job/Gkf6YZj42QQjfj105X31GYXB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_staraligner/7)
<!-- Reviewable:end -->
